### PR TITLE
Add unit declarator to class and role declarations

### DIFF
--- a/lib/Email/MIME.pm6
+++ b/lib/Email/MIME.pm6
@@ -7,7 +7,7 @@ use Email::MIME::Exceptions;
 use MIME::QuotedPrint;
 use Email::MIME::Encoder::Base64;
 
-class Email::MIME is Email::Simple does Email::MIME::ParseContentType;
+unit class Email::MIME is Email::Simple does Email::MIME::ParseContentType;
 
 has $!ct;
 has @!parts;

--- a/lib/Email/MIME/Encoder/Base64.pm6
+++ b/lib/Email/MIME/Encoder/Base64.pm6
@@ -1,5 +1,5 @@
 use v6;
-class Email::MIME::Encoder::Base64;
+unit class Email::MIME::Encoder::Base64;
 
 use MIME::Base64;
 

--- a/lib/Email/MIME/Header.pm6
+++ b/lib/Email/MIME/Header.pm6
@@ -4,7 +4,7 @@ use Email::Simple::Header;
 use Email::MIME::Encoder::Base64;
 use MIME::QuotedPrint;
 
-class Email::MIME::Header is Email::Simple::Header;
+unit class Email::MIME::Header is Email::Simple::Header;
 
 grammar EncodedHeader {
     regex TOP {

--- a/lib/Email/MIME/ParseContentType.pm6
+++ b/lib/Email/MIME/ParseContentType.pm6
@@ -1,4 +1,4 @@
-role Email::MIME::ParseContentType;
+unit role Email::MIME::ParseContentType;
 
 grammar ContentTypeHeader {
     token TOP {


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `grammar` or `role` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.