### PR TITLE
Don't stringify Nil if content-type is Nil

### DIFF
--- a/lib/Email/MIME.pm6
+++ b/lib/Email/MIME.pm6
@@ -284,14 +284,15 @@ method boundary-set($data) {
         $ct-hash<attributes><boundary>:delete;
     }
     self!compose-content-type($ct-hash);
-    
+
     if +self.parts > 1 {
         self.parts-set(self.parts)
     }
 }
 
 method content-type(){
-  return ~self.header("Content-type");
+    return ~$_ with self.header("Content-type");
+    return '';
 }
 
 method content-type-set($ct) {


### PR DESCRIPTION
Small fix to prevent this warning:

```
Use of Nil in string context
  in method content-type at /usr/local/Cellar/rakudo-star/2019.03/share/perl6/site/sources/CE2F9EE6BB0EA068987D48711B20EC8B84410730 (Email::MIME) line 294
```