### PR TITLE
Remove use of deprecated function

### DIFF
--- a/lib/Email/MIME.pm6
+++ b/lib/Email/MIME.pm6
@@ -520,5 +520,5 @@ method !create-boundary {
 }
 
 method !create-cid {
-    return self!create-boundary ~ '@' ~ gethostname;
+    return self!create-boundary ~ '@' ~ $*KERNEL.hostname();
 }


### PR DESCRIPTION
gethostname() will be removed from Raku at some point in the future.  $*KERNEL.hostname() is the recommended call.
