### PR TITLE
Fix setting filename

### DIFF
--- a/lib/Email/MIME.pm6
+++ b/lib/Email/MIME.pm6
@@ -184,7 +184,7 @@ method filename-set($filename) {
     for $params.keys {
         $dis ~= '; ' ~ $_ ~ '="' ~ $params{$_} ~ '"';
     }
-    self.header-set($dis);
+    self.header-set('Content-Disposition', $dis);
 }
 
 method subparts {


### PR DESCRIPTION
The disposition header was set incorrectly causing filename set calls to silently do nothing.