### PR TITLE
Base64 native encoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.precomp/

--- a/META6.json
+++ b/META6.json
@@ -19,6 +19,7 @@
   "provides": {
     "Email::MIME": "lib/Email/MIME.pm6",
     "Email::MIME::Encoder::Base64": "lib/Email/MIME/Encoder/Base64.pm6",
+    "Email::MIME::Encoder::Base64Native": "lib/Email/MIME/Encoder/Base64Native.pm6",
     "Email::MIME::Exceptions": "lib/Email/MIME/Exceptions.pm6",
     "Email::MIME::Header": "lib/Email/MIME/Header.pm6",
     "Email::MIME::ParseContentType": "lib/Email/MIME/ParseContentType.pm6"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ This is a port of perl 5's Email::MIME.
                                  body-str => 'Hello«World');
     say ~$new;
 
+## Faster Base64 Encoding ##
+
+To benefit from faster Base64 encoding and decoding install the `Base64::Native` module
+which will be auto-detected and used automatically.
+
 ## Methods ##
 
  -  `new(Str $text)`

--- a/lib/Email/MIME.pm6
+++ b/lib/Email/MIME.pm6
@@ -6,6 +6,7 @@ use Email::MIME::Exceptions;
 
 use MIME::QuotedPrint;
 use Email::MIME::Encoder::Base64;
+use Email::MIME::Encoder::Base64Native;
 
 unit class Email::MIME is Email::Simple does Email::MIME::ParseContentType;
 
@@ -396,8 +397,13 @@ method !reset-cids {
 # content transfer encoding stuff here
 ###
 
-my %cte-coders = ('base64' => Email::MIME::Encoder::Base64,
-                  'quoted-printable' => MIME::QuotedPrint);
+my %cte-coders = ('quoted-printable' => MIME::QuotedPrint);
+if (try require Base64::Native) !=== Nil {
+    %cte-coders<base64> = Email::MIME::Encoder::Base64Native.new;
+}
+else {
+    %cte-coders<base64> = Email::MIME::Encoder::Base64.new;
+}
 
 method set-encoding-handler($cte, $coder) {
     %cte-coders{$cte} = $coder;

--- a/lib/Email/MIME.pm6
+++ b/lib/Email/MIME.pm6
@@ -24,7 +24,7 @@ method _finish_new(){
     self.fill-parts;
 }
 
-method create(:$header is copy, :$header-str is copy, :$attributes is copy, :$parts is copy, :$body, :$body-str) {
+method create(:$header is copy, :$header-str is copy, :$attributes is copy, :$parts is copy, :$body, :$body-str, :$body-raw) {
     my $self = callwith(header => Array.new(), body => '', header-class => Email::MIME::Header);
 
     $self.header-set('Content-Type', 'text/plain');
@@ -101,6 +101,8 @@ method create(:$header is copy, :$header-str is copy, :$attributes is copy, :$pa
         $self.body-set($body);
     } elsif $body-str {
         $self.body-str-set($body-str);
+    } elsif $body-raw {
+        $self.body-raw-set($body-raw);
     }
 
     return $self;

--- a/lib/Email/MIME/Encoder/Base64Native.pm6
+++ b/lib/Email/MIME/Encoder/Base64Native.pm6
@@ -1,0 +1,33 @@
+use v6;
+unit class Email::MIME::Encoder::Base64Native;
+
+has &!base64-encode = (try require Base64::Native) !=== Nil
+    ?? ::('Base64::Native::&base64-encode')
+    !! sub () { die 'Base64::Native not installed. Can\'t use Email::MIME::Encode::Base64Native.' };
+has &!base64-decode = (try require Base64::Native) !=== Nil
+    ?? ::('Base64::Native::&base64-decode')
+    !! sub () { die 'Base64::Native not installed. Can\'t use Email::MIME::Encode::Base64Native.' };
+
+method encode($text, :$mime-header) {
+    my $enc = &!base64-encode($text, :str);
+    if $mime-header {
+        return $enc;
+    }
+    else {
+        my $max-line-len = 76;
+        my $lstr = '';
+        my $pos = 0;
+        my $len = $enc.chars;
+        while $pos + $max-line-len < $len {
+            $lstr ~= $enc.substr: $pos, $max-line-len;
+            $lstr ~= "\n";
+            $pos += $max-line-len;
+        }
+        $lstr ~= $enc.substr: $pos;
+        return $lstr;
+    }
+}
+
+method decode($encoded) {
+    return &!base64-decode($encoded).decode;
+}

--- a/t/base64.t
+++ b/t/base64.t
@@ -1,0 +1,34 @@
+use v6;
+
+use Test;
+
+use lib 'lib';
+use Email::MIME;
+
+plan 2;
+
+my $email-text = 'Some body text';
+my $email-raw = 'U29tZSBib2R5IHRleHQ=';
+
+{
+    my $email = Email::MIME.create(
+        attributes => {
+            content-type => 'text/plain',
+            charset      => 'utf-8',
+            encoding     => 'base64',
+        },
+        body-str => $email-text);
+    is $email.body-raw, $email-raw, 'Base64 encoding works';
+}
+
+{
+    my $email = Email::MIME.create(
+        attributes => {
+            content-type => 'text/plain',
+            charset      => 'utf-8',
+            encoding     => 'base64',
+        },
+        body-raw => $email-raw);
+    is $email.body-str, $email-text, 'Base64 decoding works';
+}
+


### PR DESCRIPTION
This uses the `Base64::Native` module. The module is autodetected and only
used when it's installed. When it's not installed it falls back to the
pure Raku MIME::Base64 implementation.