### PR TITLE
Fix minor bugs

### DIFF
--- a/lib/Email/MIME/AttributeHeaderParsing.pm6
+++ b/lib/Email/MIME/AttributeHeaderParsing.pm6
@@ -29,7 +29,7 @@ my grammar AttributeHeader {
         <-[\s']>+
     }
     token name {
-        \w+
+        <[\w-]>+
     }
     token value {
         <-[";]>+

--- a/lib/Email/MIME/Header.pm6
+++ b/lib/Email/MIME/Header.pm6
@@ -76,7 +76,9 @@ method set-encoding-handler($encoding, $handler){
 }
 
 method header-str($header, :$multi) {
-    my $values = self.header($header, :$multi);
+    unless my $values = self.header($header, :$multi) {
+        return $multi ?? () !! Nil
+    }
     for $values.list -> $value is rw {
         $value = EncodedHeader.parse($value, :actions(EncodedHeader::Actions.new)).made;
     }


### PR DESCRIPTION
- Allow `-` in attribute names. Stumbled upon `creation-date`, for example.
- Don't die in `header-str` when there is no header.